### PR TITLE
Split metadata class and move the "Property" logic to its own class.

### DIFF
--- a/src/Tuicha/Fluent/Filter.php
+++ b/src/Tuicha/Fluent/Filter.php
@@ -580,9 +580,9 @@ abstract class Filter
     protected function normalize(Metadata $metadata, array $query)
     {
         foreach ($metadata->getProperties() as $property) {
-            if ($property['phpName'] !== $property['mongoName'] && array_key_exists($property['phpName'], $query) && !array_key_exists($property['mongoName'], $query)) {
-                $query[$property['mongoName']] = $query[$property['phpName']];
-                unset($query[$property['phpName']]);
+            if ($property->php() !== $property->mongo() && array_key_exists($property->php(), $query) && !array_key_exists($property->mongo(), $query)) {
+                $query[$property->mongo()] = $query[$property->php()];
+                unset($query[$property->php()]);
             }
         }
 

--- a/src/Tuicha/Metadata.php
+++ b/src/Tuicha/Metadata.php
@@ -443,52 +443,6 @@ class Metadata
     }
 
     /**
-     * Get the type definition from a single Annotation.
-     *
-     * @return array
-     */
-    protected function getDataTypeFromAnnotation(Annotation $annotation)
-    {
-        $type = new DataType($annotation->getName());
-
-        switch ($annotation->getName()) {
-        case 'class':
-            $type->addData('class', strtolower($annotation->getArg()));
-            break;
-        case 'array':
-            try {
-                $type->addData('element', $this->getDataTypeFromAnnotation($annotation->getArg()));
-            } catch (RuntimeException $e) {
-            }
-            break;
-        case 'reference':
-            foreach ($annotation->getArgs() as $name => $value) {
-                $type->addData($name, $value);
-            }
-            break;
-        }
-
-        return $type;
-    }
-
-    /**
-     * Returns the data type definition for a property
-     *
-     * @param Annotations $annotations  Property's annotations object
-     *
-     * @return array
-     */
-    protected function getDataType(Annotations $annotations)
-    {
-        $types = 'int,integer,float,double,array,bool,boolean,string,object,class,type,id,reference';
-        if ($annotation = $annotations->getOne($types)) {
-            return $this->getDataTypeFromAnnotation($annotation);
-        }
-
-        return new DataType;
-    }
-
-    /**
      * Processes properties
      *
      * Processes properties from a class and extracts all the metadata for future

--- a/src/Tuicha/Metadata.php
+++ b/src/Tuicha/Metadata.php
@@ -361,9 +361,7 @@ class Metadata
 
         if (is_array($value)) {
             // Change the data type for the element
-            $childDefinition = [
-                'type' => $definition ? $definition['type']->getData('element', new DataType) : new DataType,
-            ];
+            $childDefinition = (new Property(''))->setType($definition ? $definition->getType()->getData('element', new DataType) : new DataType);
 
             foreach ($value as $key => $val) {
                 $this->serializeValue($propertyName, $childDefinition, $val, $validate);
@@ -374,17 +372,17 @@ class Metadata
         if (is_object($value)) {
             $class = strtolower(get_class($value));
             $meta  = Metadata::of($class);
-            if ($definition && $definition['type']->is('reference')) {
+            if ($definition && $definition->getType()->is('reference')) {
                 $value = $meta->makeReference(
                     $this->save($value),
-                    $definition['type']->getData('with', []),
-                    $definition['type']->getData('readonly')
+                    $definition->getType()->getData('with', []),
+                    $definition->getType()->getData('readonly')
                 );
                 return true;
             }
 
             $value = $meta->toDocument($value, $validate);
-            if (!$definition || $definition['type']->getData('class') !== $class) {
+            if (!$definition || $definition->getType()->getData('class') !== $class) {
                 // Tuicha must save the object class name to be able to populate it back.
                 $value['__class'] = $class;
             }

--- a/src/Tuicha/Metadata.php
+++ b/src/Tuicha/Metadata.php
@@ -1048,8 +1048,8 @@ class Metadata
     {
         if (!empty($this->phpProperties[$property])) {
             return $this->phpProperties[$property]->getValue($object);
-        } else if (!empty($object->$property)) {
-            $value = $object->$property;
+        } else if (array_key_exists($property, (array)$object)) {
+            return $object->$property;
         }
 
         return null;

--- a/src/Tuicha/Metadata.php
+++ b/src/Tuicha/Metadata.php
@@ -382,6 +382,7 @@ class Metadata
             }
 
             $value = $meta->toDocument($value, $validate);
+            var_dump($value);
             if (!$definition || $definition->getType()->getData('class') !== $class) {
                 // Tuicha must save the object class name to be able to populate it back.
                 $value['__class'] = $class;

--- a/src/Tuicha/Metadata.php
+++ b/src/Tuicha/Metadata.php
@@ -329,13 +329,13 @@ class Metadata
      *   5. Any object is serialized with their own Metadata object (Metadata::serializeValue)
      *
      * @param string $propertyName  Property name
-     * @param array  $definition    Proprety definition
      * @param mixed  &$value        Value to serialize. It is by reference, it is OK to edit it in place.
+     * @param Property $definition  Proprety definition
      * @param boolean $validate     Whether or not to validate
      *
      * @return boolean TRUE if the property was serialized, FALSE if it should be ignored.
      */
-    protected function serializeValue($propertyName, $definition, &$value, $validate = true)
+    protected function serializeValue($propertyName, &$value, Property $definition = null, $validate = true)
     {
         if (substr($propertyName, 0, 2) === '__' || is_resource($value)) {
             return false;
@@ -364,7 +364,7 @@ class Metadata
             $childDefinition = (new Property(''))->setType($definition ? $definition->getType()->getData('element', new DataType) : new DataType);
 
             foreach ($value as $key => $val) {
-                $this->serializeValue($propertyName, $childDefinition, $val, $validate);
+                $this->serializeValue($propertyName, $val, $childDefintion, $validate);
                 $value[$key] = $val;
             }
         }
@@ -1005,7 +1005,7 @@ class Metadata
         foreach ($this->phpProperties as $key => $property) {
             $value = $property->getValue($object);
 
-            if (!$this->serializeValue($key, $property, $value, $validate)) {
+            if (!$this->serializeValue($key, $value, $property, $validate)) {
                 continue;
             }
 
@@ -1015,7 +1015,7 @@ class Metadata
 
         foreach (get_object_vars($object) as $key => $value) {
             if (empty($this->phpProperties[$key]) && empty($this->mongoProperties[$key])) {
-                if (!$this->serializeValue($key, [], $value, $validate)) {
+                if (!$this->serializeValue($key, $value, null, $validate)) {
                     continue;
                 }
                 $array[$key] = $value;

--- a/src/Tuicha/Metadata/Property.php
+++ b/src/Tuicha/Metadata/Property.php
@@ -2,8 +2,10 @@
 
 namespace Tuicha\Metadata;
 
+use Notoj\Annotation\Annotation;
 use Notoj\Annotation\Annotations;
 use Notoj\ReflectionProperty;
+use RuntimeException;
 
 class Property
 {
@@ -19,21 +21,22 @@ class Property
     protected $required = false;
     protected $isPublic = true;
 
-    public function __construct($phpName, $mongoName = null, $reflection = null)
+    public function __construct($phpName, $mongoName = null, ReflectionProperty $reflection = null)
     {
+        $this->phpName   = $phpName;
+        $this->mongoName = $mongoName ?: $phpName;
+        $this->type      = $this->type ?: new DataType($mongoName === '_id' ? 'id' : '');
+
         if ($reflection) {
             $annotations = $reflection->getAnnotations();
-            $phpName     = $reflection->getName();
-            $mongoName   = $annotations->has('field') ? $annotations->getOne('field')->getArg(0) : $phpName;
+            $this->phpName   = $reflection->getName();
+            $this->mongoName = $annotations->has('field') ? $annotations->getOne('field')->getArg(0) : $this->phpName;
             if ($annotations->has('id')) {
-                $mongoName = '_id';
+                $this->mongoName = '_id';
             }
 
             $this->parseReflection($reflection, $annotations);
         }
-        $this->phpName   = $phpName;
-        $this->mongoName = $mongoName ?: $phpName;
-        $this->type      = new DataType($mongoName === '_id' ? 'id' : '');
     }
 
     public function parseReflection(ReflectionProperty $reflection, Annotations $annotations)
@@ -42,6 +45,7 @@ class Property
         $this->isPublic    = $reflection->isPublic();
         $this->required    = $annotations->has('required');
         $this->validations = $this->getAnnotationArguments($annotations->get('validate'));
+        $this->type        = $this->parseDataType($annotations);
     }
 
     /**
@@ -92,6 +96,52 @@ class Property
     public function isPublic()
     {
         return $this->isPublic;
+    }
+
+    /**
+     * Get the type definition from a single Annotation.
+     *
+     * @return array
+     */
+    protected function getDataTypeFromAnnotation(Annotation $annotation)
+    {
+        $type = new DataType($annotation->getName());
+
+        switch ($annotation->getName()) {
+        case 'class':
+            $type->addData('class', strtolower($annotation->getArg()));
+            break;
+        case 'array':
+            try {
+                $type->addData('element', $this->getDataTypeFromAnnotation($annotation->getArg()));
+            } catch (RuntimeException $e) {
+            }
+            break;
+        case 'reference':
+            foreach ($annotation->getArgs() as $name => $value) {
+                $type->addData($name, $value);
+            }
+            break;
+        }
+
+        return $type;
+    }
+
+    /**
+     * Returns the data type definition for a property
+     *
+     * @param Annotations $annotations  Property's annotations object
+     *
+     * @return array
+     */
+    protected function parseDataType(Annotations $annotations)
+    {
+        $types = 'int,integer,float,double,array,bool,boolean,string,object,class,type,id,reference';
+        if ($annotation = $annotations->getOne($types)) {
+            return $this->getDataTypeFromAnnotation($annotation);
+        }
+
+        return $this->mongoName === '_id' ?  new DataType('id') : $this->type;
     }
 
     public function getType()

--- a/src/Tuicha/Metadata/Property.php
+++ b/src/Tuicha/Metadata/Property.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace Tuicha\Metadata;
+
+use Notoj\Annotation\Annotations;
+use Notoj\ReflectionProperty;
+
+class Property
+{
+    protected $phpName;
+    protected $mongoName;
+    
+    protected $annotations = [];
+
+    protected $validations = [];
+
+    protected $type;
+
+    protected $required = false;
+    protected $isPublic = true;
+
+    public function __construct($phpName, $mongoName = null, $reflection = null)
+    {
+        if ($reflection) {
+            $annotations = $reflection->getAnnotations();
+            $phpName     = $reflection->getName();
+            $mongoName   = $annotations->has('field') ? $annotations->getOne('field')->getArg(0) : $phpName;
+            if ($annotations->has('id')) {
+                $mongoName = '_id';
+            }
+
+            $this->parseReflection($reflection, $annotations);
+        }
+        $this->phpName   = $phpName;
+        $this->mongoName = $mongoName ?: $phpName;
+        $this->type      = new DataType($mongoName === '_id' ? 'id' : '');
+    }
+
+    public function parseReflection(ReflectionProperty $reflection, Annotations $annotations)
+    {
+
+        $this->isPublic    = $reflection->isPublic();
+        $this->required    = $annotations->has('required');
+        $this->validations = $this->getAnnotationArguments($annotations->get('validate'));
+    }
+
+    /**
+     * Returns all the arguments from an array of annotations
+     *
+     * @param array $annotations An array of Notoj\Annotation\Annotation objects
+     *
+     * @return array
+     */
+    protected function getAnnotationArguments(array $annotations)
+    {
+        $arguments = [];
+        foreach ($annotations as $annotation) {
+            foreach ($annotation->getArgs() as $arg) {
+                $arguments[] = $arg;
+            }
+        }
+
+        foreach ($arguments as $id => $function) {
+            $args = [];
+            if ($function instanceof Annotation) {
+                $args     = $function->getArgs();
+                $function = $function->getName();
+            }
+
+            if (is_callable([Validation::class, $function])) {
+                $function = [Validation::class, $function];
+            } else if (is_string($function) && strpos($function, "::") > 0) {
+                $function = explode("::", $function, 2);
+            }
+            $arguments[$id] = [$function, $args];
+        }
+
+        return $arguments;
+    }
+
+
+    public function mongo()
+    {
+        return $this->mongoName;
+    }
+
+    public function php()
+    {
+        return $this->phpName;
+    }
+    
+    public function isPublic()
+    {
+        return $this->isPublic;
+    }
+
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    public function getValue($object)
+    {
+        if ($this->isPublic) {
+            return $object->{$this->phpName};
+        }
+        
+        $reflection = new ReflectionProperty($object, $this->phpName);
+        $reflection->setAccessible(true);
+        return $reflection->getValue($object);
+    }
+
+    public function setValue($object, $value)
+    {
+        if ($this->isPublic) {
+            $object->{$this->phpName} = $value;
+        } else {
+            $property = new ReflectionProperty($object, $this->phpName);
+            $property->setAccessible(true);
+            $property->setValue($object, $value);
+        }
+    }
+
+    /**
+     * Validates a property's value
+     *
+     * @param mixed  $value         Property value
+     *
+     * @return mixed
+     */
+    public function validate($value)
+    {
+        if (empty($value) && $definition['required']) {
+            throw new UnexpectedValueException("Unexpected empty value for property {$this->phpName}");
+        } else if ($value && !empty($definition['validations'])) {
+            foreach ($definition['validations'] as $validation) {
+                $response = true;
+                if (is_array($validation[0])) {
+                    list($class, $method) = $validation[0];
+                    $response = $class::$method($value, $validation[1]);
+                } else if (is_callable($validation[0])) {
+                    $response = $validation[0]($value, $validation[1]);
+                }
+
+                if (!$response) {
+                    throw new UnexpectedValueException("Invalid value for {$this->phpName} ($value)");
+                }
+            }
+        }
+
+        return $value;
+    }
+
+}

--- a/src/Tuicha/Metadata/Property.php
+++ b/src/Tuicha/Metadata/Property.php
@@ -5,6 +5,8 @@ namespace Tuicha\Metadata;
 use Notoj\Annotation\Annotation;
 use Notoj\Annotation\Annotations;
 use Notoj\ReflectionProperty;
+use Tuicha\Validation;
+use UnexpectedValueException;
 use RuntimeException;
 
 class Property
@@ -181,10 +183,10 @@ class Property
      */
     public function validate($value)
     {
-        if (empty($value) && $definition['required']) {
+        if (empty($value) && $this->required) {
             throw new UnexpectedValueException("Unexpected empty value for property {$this->phpName}");
-        } else if ($value && !empty($definition['validations'])) {
-            foreach ($definition['validations'] as $validation) {
+        } else if ($value && !empty($this->validations)) {
+            foreach ($this->validations as $validation) {
                 $response = true;
                 if (is_array($validation[0])) {
                     list($class, $method) = $validation[0];

--- a/src/Tuicha/Metadata/Property.php
+++ b/src/Tuicha/Metadata/Property.php
@@ -11,13 +11,9 @@ class Property
 {
     protected $phpName;
     protected $mongoName;
-    
     protected $annotations = [];
-
     protected $validations = [];
-
     protected $type;
-
     protected $required = false;
     protected $isPublic = true;
 
@@ -82,22 +78,6 @@ class Property
         return $arguments;
     }
 
-
-    public function mongo()
-    {
-        return $this->mongoName;
-    }
-
-    public function php()
-    {
-        return $this->phpName;
-    }
-    
-    public function isPublic()
-    {
-        return $this->isPublic;
-    }
-
     /**
      * Get the type definition from a single Annotation.
      *
@@ -144,9 +124,30 @@ class Property
         return $this->mongoName === '_id' ?  new DataType('id') : $this->type;
     }
 
+    public function mongo()
+    {
+        return $this->mongoName;
+    }
+
+    public function php()
+    {
+        return $this->phpName;
+    }
+
+    public function isPublic()
+    {
+        return $this->isPublic;
+    }
+
     public function getType()
     {
         return $this->type;
+    }
+
+    public function setType(DataType $type)
+    {
+        $this->type = $type;
+        return $this;
     }
 
     public function getValue($object)
@@ -154,7 +155,7 @@ class Property
         if ($this->isPublic) {
             return $object->{$this->phpName};
         }
-        
+
         $reflection = new ReflectionProperty($object, $this->phpName);
         $reflection->setAccessible(true);
         return $reflection->getValue($object);

--- a/src/Tuicha/Reference.php
+++ b/src/Tuicha/Reference.php
@@ -147,7 +147,7 @@ class Reference implements Serializable
     public function __get($name)
     {
         $property= !empty($this->properties[$name]) ? $this->properties[$name] : null;
-        if ($property && $property['type']->is('id')) {
+        if ($property && $property->getType()->is('id')) {
             // there is no need to load the referenced object
             // to return its ID
             return $this->id;

--- a/tests/FindTest.php
+++ b/tests/FindTest.php
@@ -60,7 +60,7 @@ class FindTest extends PHPUnit\Framework\TestCase
 
     public function testCreateIndex()
     {
-        $this->assertTrue(User::createIndexes() instanceof MongoDB\Driver\Cursor);
+        $this->assertEquals(MongoDB\Driver\Cursor::class, get_class(User::createIndexes()));
     }
 
     public function testCountZero()

--- a/tests/MetadataTest.php
+++ b/tests/MetadataTest.php
@@ -113,5 +113,16 @@ class MetadataTest extends PHPUnit\Framework\TestCase
         $this->assertTrue(is_array($properties));
         $this->assertFalse(empty($properties));
         $this->assertTrue(array_key_exists('name', $properties));
+        $properties = User::getTuichaMetadata()->getPropertiesByAnnotation('@requiredxxxo');
+        $this->assertEquals([], $properties);
+    }
+
+    public function testgetPropertyValue()
+    {
+        $user = new User;
+        $user->xxx = false;
+        $meta = User::getTuichaMetadata();
+        $this->assertEquals($user->xxx, $meta->getPropertyValue($user, 'xxx'));
+        $this->assertNull($meta->getPropertyValue($user, 'yyy'));
     }
 }


### PR DESCRIPTION
Before this PR all the information was stored in arrays and the `Tuicha\Metadata` class was growing too much.  This PR separates all the *property* logic to its own class (`Tuicha\Metatada\Property`).